### PR TITLE
Add `prioritizationFeeLamports` config to `/swap` and `/swap-instructions` APIs

### DIFF
--- a/jupiter-swap-api-client/src/swap.rs
+++ b/jupiter-swap-api-client/src/swap.rs
@@ -1,7 +1,7 @@
 use crate::{
     quote::QuoteResponse, serde_helpers::field_as_string, transaction_config::TransactionConfig,
 };
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,

--- a/jupiter-swap-api-client/src/transaction_config.rs
+++ b/jupiter-swap-api-client/src/transaction_config.rs
@@ -12,6 +12,20 @@ pub enum ComputeUnitPriceMicroLamports {
     Auto,
 }
 
+#[derive(Deserialize, Serialize, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+// #[serde(untagged)]
+pub enum PrioritizationFeeLamports {
+    /// Jupiter will automatically set a priority fee,
+    /// and it will be capped at 5,000,000 lamports / 0.005 SOL
+    #[serde(deserialize_with = "auto")]
+    Auto,
+    /// The priority fee will be a multiplier on the auto fee.
+    AutoMultiplier(u64),
+    /// A tip instruction will be included to Jito and no priority fee will be set.
+    JitoTipLamports(u64)
+}
+
 fn auto<'de, D>(deserializer: D) -> Result<(), D::Error>
 where
     D: Deserializer<'de>,
@@ -39,6 +53,9 @@ pub struct TransactionConfig {
     pub destination_token_account: Option<Pubkey>,
     /// compute unit price to prioritize the transaction, the additional fee will be compute unit consumed * computeUnitPriceMicroLamports
     pub compute_unit_price_micro_lamports: Option<ComputeUnitPriceMicroLamports>,
+    /// Prioritization fee lamports paid for the transaction in addition to the signatures fee.
+    /// Mutually exclusive with `compute_unit_price_micro_lamports`.
+    pub prioritization_fee_lamports: Option<PrioritizationFeeLamports>,
     /// Request a legacy transaction rather than the default versioned transaction, needs to be paired with a quote using asLegacyTransaction otherwise the transaction might be too large
     ///
     /// Default: false
@@ -62,6 +79,7 @@ impl Default for TransactionConfig {
             fee_account: None,
             destination_token_account: None,
             compute_unit_price_micro_lamports: None,
+            prioritization_fee_lamports: None,
             as_legacy_transaction: false,
             use_shared_accounts: true,
             use_token_ledger: false,

--- a/jupiter-swap-api-client/src/transaction_config.rs
+++ b/jupiter-swap-api-client/src/transaction_config.rs
@@ -58,7 +58,7 @@ pub struct TransactionConfig {
     pub prioritization_fee_lamports: Option<PrioritizationFeeLamports>,
     /// When enabled, it will do a swap simulation to get the compute unit used and set it in ComputeBudget's compute unit limit.
     /// This will increase latency slightly since there will be one extra RPC call to simulate this. Default is false.
-    pub dynamic_compute_unit_limit: Option<bool>,
+    pub dynamic_compute_unit_limit: bool,
     /// Request a legacy transaction rather than the default versioned transaction, needs to be paired with a quote using asLegacyTransaction otherwise the transaction might be too large
     ///
     /// Default: false
@@ -83,7 +83,7 @@ impl Default for TransactionConfig {
             destination_token_account: None,
             compute_unit_price_micro_lamports: None,
             prioritization_fee_lamports: None,
-            dynamic_compute_unit_limit: None,
+            dynamic_compute_unit_limit: false,
             as_legacy_transaction: false,
             use_shared_accounts: true,
             use_token_ledger: false,

--- a/jupiter-swap-api-client/src/transaction_config.rs
+++ b/jupiter-swap-api-client/src/transaction_config.rs
@@ -56,6 +56,9 @@ pub struct TransactionConfig {
     /// Prioritization fee lamports paid for the transaction in addition to the signatures fee.
     /// Mutually exclusive with `compute_unit_price_micro_lamports`.
     pub prioritization_fee_lamports: Option<PrioritizationFeeLamports>,
+    /// When enabled, it will do a swap simulation to get the compute unit used and set it in ComputeBudget's compute unit limit.
+    /// This will increase latency slightly since there will be one extra RPC call to simulate this. Default is false.
+    pub dynamic_compute_unit_limit: Option<bool>,
     /// Request a legacy transaction rather than the default versioned transaction, needs to be paired with a quote using asLegacyTransaction otherwise the transaction might be too large
     ///
     /// Default: false
@@ -80,6 +83,7 @@ impl Default for TransactionConfig {
             destination_token_account: None,
             compute_unit_price_micro_lamports: None,
             prioritization_fee_lamports: None,
+            dynamic_compute_unit_limit: None,
             as_legacy_transaction: false,
             use_shared_accounts: true,
             use_token_ledger: false,


### PR DESCRIPTION
### Overview
This PR adds support for `prioritizationFeeLamports` according to the [/swap](https://station.jup.ag/api-v6/post-swap) and [/swap-instructions](https://station.jup.ag/api-v6/post-swap-instructions) POST definitions.

Fixes #6 